### PR TITLE
Fix ChirpLogger default constructor style

### DIFF
--- a/Runtime/Core/ChirpLogger.cs
+++ b/Runtime/Core/ChirpLogger.cs
@@ -16,6 +16,7 @@ namespace WhiteSparrow.Shared.Logging.Core
 	    {
 		    Name = name;
 		    UseChannel = useChannel;
+		    Style = new ChirpStyle();
 	    }
 	    
 	    public ChirpLogger(string name)


### PR DESCRIPTION
Fixing the default constructor for `ChirpLogger` not initializing the style